### PR TITLE
Fix missing S6 Overlay binaries

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,7 +17,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         bzip2-dev=1.0.8-r1 \
-        coreutils=9.0-r2 \
         dpkg-dev=1.20.9-r0 \
         dpkg=1.20.9-r0 \
         expat-dev=2.4.5-r0 \


### PR DESCRIPTION
# Proposed Changes

This removes the `coreutils` package from the build dependencies, because it messes with some of the S6 Overlay binaries for whatever reason. Luckily, the build happens just fine even without it, therefore I believe it's not being used at all.

## Related Issues

Fixes #102
