### PR TITLE
Prune left pycache

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -113,13 +113,6 @@ RUN \
         --no-cache-dir \
         "pip==$PYTHON_PIP_VERSION" \
     \
-    && find /usr/local -depth \
-        \( \
-            \( -type d -a \( -name test -o -name tests \) \) \
-            -o \
-            \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-        \) -exec rm -rf '{}' +  \
-    \
     && apk del --no-cache --purge .build-dependencies \
     && rm -f -r \
         /usr/src \
@@ -127,7 +120,14 @@ RUN \
         /tmp/* \
     \
     && python3 --version \
-    && pip3 --version
+    && pip3 --version \
+    \
+    && find /usr/local -depth \
+        \( \
+            \( -type d -a \( -name test -o -name tests \) \) \
+            -o \
+            \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+        \) -exec rm -rf '{}' +
 
 # Entrypoint & CMD
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
# Proposed Changes

This moves the command which prunes the pycache to after the last `python` and `pip` command are called, because they also generate pycache, even when only for `--version`.

The same is done in the official python image:

https://github.com/docker-library/python/blob/e0dacc4c580f4ad0aa68136789add4e37bdaab91/3.10/alpine3.15/Dockerfile#L140-L148

Notice that `find [...]` is called after `pip --version`, and not before.

With this, we reduce the size of the final image:

```console
$ container-diff diff daemon://old daemon://remove-python-cache --type=size

-----Size-----

Image size difference between old and remove-python-cache:
SIZE1         SIZE2
119.5M        115.4M
```

## Related Issues

None.
